### PR TITLE
use length \linewidth instead of \textwidth in \awesomebox

### DIFF
--- a/awesomebox.sty
+++ b/awesomebox.sty
@@ -75,7 +75,7 @@
 \newcommand{\awesomebox}[4]{%
   \vspace{\aweboxvskip}
   \noindent
-  \begin{tabularx}{\textwidth}{%
+  \begin{tabularx}{\linewidth}{%
       m{\aweboxleftmargin}!{\color{#3}\vrule width #2}X}
     \raisebox{\aweboxsignraise}{\textcolor{#3}{\Huge\ABFamily#1}} & #4 \\
   \end{tabularx}


### PR DESCRIPTION
Using \linewidth as box width allows to use the box inside another environment (e.g. in a list) and respect the right margin. Great package BTW!